### PR TITLE
Implement Validations for `/subscriptions` Endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,9 +285,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
@@ -421,6 +421,15 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "claim"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81099d6bb72e1df6d50bb2347224b666a670912bb7f06dbe867a4a070ab3ce8"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1238,11 +1247,10 @@ checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -1339,6 +1347,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "chrono",
+ "claim",
  "config",
  "once_cell",
  "reqwest",
@@ -1352,7 +1361,9 @@ dependencies = [
  "tracing-bunyan-formatter",
  "tracing-log 0.2.0",
  "tracing-subscriber",
+ "unicode-segmentation",
  "uuid",
+ "validator",
 ]
 
 [[package]]
@@ -2896,6 +2907,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "validator"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db79c75af171630a3148bd3e6d7c4f42b6a9a014c2945bc5ed0020cbb8d9478e"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +669,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +710,16 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fake"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c25829bde82205da46e1823b2259db6273379f626fc211f126f65654a2669be"
+dependencies = [
+ "deunicode",
+ "rand",
+]
 
 [[package]]
 name = "fastrand"
@@ -1349,7 +1375,11 @@ dependencies = [
  "chrono",
  "claim",
  "config",
+ "fake",
  "once_cell",
+ "quickcheck",
+ "quickcheck_macros",
+ "rand",
  "reqwest",
  "secrecy",
  "serde",
@@ -1697,6 +1727,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,8 @@ features = [
 ]
 
 [dev-dependencies]
+fake = "2"
+quickcheck = "1"
+quickcheck_macros = "1"
+rand = "0.8"
 reqwest = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 actix-web = "4"
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
+claim = "0.5"
 config = "0.14"
 once_cell = "1"
 secrecy = { version = "0.8", features = ["serde"] }
@@ -26,7 +27,9 @@ tracing-actix-web = "0.7"
 tracing-bunyan-formatter = "0.3"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
+unicode-segmentation = "1"
 uuid = { version = "1", features = ["v4"] }
+validator = "0.18"
 
 [dependencies.sqlx]
 version = "0.7"

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,7 @@
+pub mod new_subscriber;
+pub mod subscriber_email;
+pub mod subscriber_name;
+
+pub use new_subscriber::NewSubscriber;
+pub use subscriber_email::SubscriberEmail;
+pub use subscriber_name::SubscriberName;

--- a/src/domain/new_subscriber.rs
+++ b/src/domain/new_subscriber.rs
@@ -1,0 +1,7 @@
+use crate::domain::subscriber_email::SubscriberEmail;
+use crate::domain::subscriber_name::SubscriberName;
+
+pub struct NewSubscriber {
+    pub email: SubscriberEmail,
+    pub name: SubscriberName,
+}

--- a/src/domain/subscriber_email.rs
+++ b/src/domain/subscriber_email.rs
@@ -1,0 +1,56 @@
+use validator::ValidateEmail;
+
+#[derive(Debug)]
+pub struct SubscriberEmail(String);
+
+impl SubscriberEmail {
+    pub fn parse(s: String) -> Result<Self, String> {
+        if ValidateEmail::validate_email(&s) {
+            Ok(Self(s))
+        } else {
+            Err("Invalid email address".into())
+        }
+    }
+}
+
+impl AsRef<str> for SubscriberEmail {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claim::{assert_err, assert_ok};
+
+    #[test]
+    fn empty_string_is_rejected() {
+        let email = "".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn email_missing_at_symbol_is_rejected() {
+        let email = "ursula.example.com".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn email_missing_subject_is_rejected() {
+        let email = "@example.com".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn email_missing_domain_is_rejected() {
+        let email = "ursula@".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn valid_email_is_accepted() {
+        let email = "ursula@example.com".to_string();
+        assert_ok!(SubscriberEmail::parse(email));
+    }
+}

--- a/src/domain/subscriber_name.rs
+++ b/src/domain/subscriber_name.rs
@@ -1,0 +1,85 @@
+use unicode_segmentation::UnicodeSegmentation;
+
+#[derive(Debug)]
+pub struct SubscriberName(String);
+
+impl SubscriberName {
+    pub fn parse(s: String) -> Result<Self, String> {
+        if Self::is_empty_or_whitespace(&s)
+            || Self::is_too_long(&s)
+            || Self::contains_forbidden_characters(&s)
+        {
+            Err("Invalid subscriber name".into())
+        } else {
+            Ok(Self(s))
+        }
+    }
+
+    fn is_empty_or_whitespace(s: &str) -> bool {
+        s.trim().is_empty()
+    }
+
+    /// Calculate the length of the string in graphemes instead of characters
+    fn is_too_long(s: &str) -> bool {
+        s.graphemes(true).count() > 256
+    }
+
+    fn contains_forbidden_characters(s: &str) -> bool {
+        let forbidden_characters = [
+            '/', '\\', '(', ')', '\'', '"', '<', '>', '&', '{', '}', '?', '#', ':',
+        ];
+        s.chars().any(|c| forbidden_characters.contains(&c))
+    }
+}
+
+impl AsRef<str> for SubscriberName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claim::{assert_err, assert_ok};
+
+    #[test]
+    fn a_256_grapheme_long_name_is_valid() {
+        let name = "ä".repeat(256);
+        assert_ok!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn a_name_longer_than_256_graphemes_is_rejected() {
+        let name = "ä".repeat(257);
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn empty_string_is_rejected() {
+        let name = "".to_string();
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn whitespace_only_names_are_rejected() {
+        let name = " ".to_string();
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn names_containing_an_invalid_character_are_rejected() {
+        for name in &[
+            '/', '\\', '(', ')', '\'', '"', '<', '>', '&', '{', '}', '?', '#', ':',
+        ] {
+            let name = name.to_string();
+            assert_err!(SubscriberName::parse(name));
+        }
+    }
+
+    #[test]
+    fn a_valid_name_is_parsed_successfully() {
+        let name = "Ursula Le Guin".to_string();
+        assert_ok!(SubscriberName::parse(name));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod configuration;
+pub mod domain;
 pub mod routes;
 pub mod startup;
 pub mod telemetry;

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -11,30 +11,29 @@ pub struct FormData {
     name: String,
 }
 
+impl TryInto<NewSubscriber> for FormData {
+    type Error = String;
+
+    fn try_into(self) -> Result<NewSubscriber, Self::Error> {
+        let email = SubscriberEmail::parse(self.email)?;
+        let name = SubscriberName::parse(self.name)?;
+        Ok(NewSubscriber { email, name })
+    }
+}
+
 #[tracing::instrument(
     name = "Adding a new subscriber",
     skip(connection_pool, form),
-    fields(
-        email = %form.email,
-        name = %form.name
-    )
+    fields(email = %form.email, name = %form.name)
 )]
 pub async fn subscribe(
     connection_pool: web::Data<PgPool>,
     form: web::Form<FormData>,
 ) -> HttpResponse {
-    let email = match SubscriberEmail::parse(form.0.email) {
-        Ok(x) => x,
+    let new_subscriber = match form.0.try_into() {
+        Ok(value) => value,
         Err(_) => return HttpResponse::BadRequest().finish(),
     };
-
-    let name = match SubscriberName::parse(form.0.name) {
-        Ok(x) => x,
-        Err(_) => return HttpResponse::BadRequest().finish(),
-    };
-
-    let new_subscriber = NewSubscriber { email, name };
-
     match insert_subscriber(&connection_pool, &new_subscriber).await {
         Ok(_) => HttpResponse::Ok().finish(),
         Err(_) => HttpResponse::InternalServerError().finish(),

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -1,3 +1,5 @@
+use crate::domain::SubscriberName;
+use crate::domain::{NewSubscriber, SubscriberEmail};
 use actix_web::{web, HttpResponse};
 use chrono::Utc;
 use sqlx::PgPool;
@@ -11,17 +13,29 @@ pub struct FormData {
 
 #[tracing::instrument(
     name = "Adding a new subscriber",
-    skip(form, connection_pool),
+    skip(connection_pool, form),
     fields(
         email = %form.email,
         name = %form.name
     )
 )]
 pub async fn subscribe(
-    form: web::Form<FormData>,
     connection_pool: web::Data<PgPool>,
+    form: web::Form<FormData>,
 ) -> HttpResponse {
-    match insert_subscriber(&form, &connection_pool).await {
+    let email = match SubscriberEmail::parse(form.0.email) {
+        Ok(x) => x,
+        Err(_) => return HttpResponse::BadRequest().finish(),
+    };
+
+    let name = match SubscriberName::parse(form.0.name) {
+        Ok(x) => x,
+        Err(_) => return HttpResponse::BadRequest().finish(),
+    };
+
+    let new_subscriber = NewSubscriber { email, name };
+
+    match insert_subscriber(&connection_pool, &new_subscriber).await {
         Ok(_) => HttpResponse::Ok().finish(),
         Err(_) => HttpResponse::InternalServerError().finish(),
     }
@@ -29,17 +43,20 @@ pub async fn subscribe(
 
 #[tracing::instrument(
     name = "Saving new subscriber details in the database",
-    skip(form, connection_pool)
+    skip(connection_pool, new_subscriber)
 )]
-async fn insert_subscriber(form: &FormData, connection_pool: &PgPool) -> Result<(), sqlx::Error> {
+async fn insert_subscriber(
+    connection_pool: &PgPool,
+    new_subscriber: &NewSubscriber,
+) -> Result<(), sqlx::Error> {
     sqlx::query!(
         r#"
         INSERT INTO subscriptions (id, email, name, subscribed_at)
         VALUES ($1, $2, $3, $4)
         "#,
         Uuid::new_v4(),
-        form.email,
-        form.name,
+        new_subscriber.email.as_ref(),
+        new_subscriber.name.as_ref(),
         Utc::now()
     )
     .execute(connection_pool)

--- a/tests/subscriptions.rs
+++ b/tests/subscriptions.rs
@@ -77,3 +77,34 @@ async fn subscribe_returns_a_400_when_data_is_missing() {
         );
     }
 }
+
+#[tokio::test]
+async fn subscribe_returns_a_400_when_fields_are_present_but_empty() {
+    // Arrange
+    let app = spawn_app().await;
+    let client = reqwest::Client::new();
+    let test_cases = vec![
+        ("name=&email=ursula_le_guin%40gmail.com", "name is empty"),
+        ("name=Ursula&email=", "email is empty"),
+        ("name=&email=", "name and email are empty"),
+    ];
+
+    for (body, description) in test_cases {
+        // Act
+        let response = client
+            .post(&format!("{}/subscriptions", &app.address))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(body)
+            .send()
+            .await
+            .expect("Failed to execute request.");
+
+        // Assert
+        assert_eq!(
+            response.status().as_u16(),
+            400,
+            "The API did not return a 400 Bad Request when {}.",
+            description
+        );
+    }
+}


### PR DESCRIPTION
This pull request includes the following changes to implement validations:

- Added tuple structs `SubscriberEmail` and `SubscriberName` to parse and wrap actual values, rejecting invalid formats.
- Introduced `fake` and `quickcheck` for property-based testing to test the email validation functionality.