### PR TITLE
Add email confirmation step for subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linkify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1401,7 @@ dependencies = [
  "claim",
  "config",
  "fake",
+ "linkify",
  "once_cell",
  "quickcheck",
  "quickcheck_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ features = ["json", "rustls-tls"]
 
 [dev-dependencies]
 fake = "2"
+linkify = "0.10"
 quickcheck = "1"
 quickcheck_macros = "1"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 claim = "0.5"
 config = "0.14"
 once_cell = "1"
+rand = { version = "0.8", features = ["std_rng"] }
 secrecy = { version = "0.8", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde-aux = "4"
@@ -53,6 +54,5 @@ fake = "2"
 linkify = "0.10"
 quickcheck = "1"
 quickcheck_macros = "1"
-rand = "0.8"
 serde_json = "1"
 wiremock = "0.6"

--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -2,6 +2,7 @@
 
 application:
   port: 8080
+  base_url: http://127.0.0.1
 
 database:
   host: localhost

--- a/configuration/production.yaml
+++ b/configuration/production.yaml
@@ -8,4 +8,4 @@ database:
 
 email_client:
   base_url: https://api.postmarkapp.com
-  # `sender_email` and `authorization_token` should be set as environment variables.
+  # `APP_EMAIL_CLIENT__SENDER_EMAIL` and `APP_EMAIL_CLIENT__AUTHORIZATION_TOKEN` should be set as environment variables.

--- a/migrations/20240610142258_add_status_to_subscriptions.sql
+++ b/migrations/20240610142258_add_status_to_subscriptions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE subscriptions ADD COLUMN status TEXT NULL;

--- a/migrations/20240610151708_make_status_not_null_in_subscriptions.sql
+++ b/migrations/20240610151708_make_status_not_null_in_subscriptions.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+    UPDATE subscriptions
+    SET status = 'confirmed'
+    WHERE status IS NULL;
+
+    ALTER TABLE subscriptions ALTER COLUMN status SET NOT NULL;
+
+COMMIT;

--- a/migrations/20240610152038_create_subscription_tokens_table.sql
+++ b/migrations/20240610152038_create_subscription_tokens_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE subscription_tokens (
+    subscription_token TEXT NOT NULL,
+    subscriber_id uuid NOT NULL
+        REFERENCES subscriptions (id),
+    PRIMARY KEY (subscription_token)
+);

--- a/spec.yaml
+++ b/spec.yaml
@@ -44,6 +44,10 @@ services:
         scope: RUN_TIME
         value: ${newsletter.DATABASE}
 
+      - key: APP_APPLICATION__BASE_URL
+        scope: RUN_TIME
+        value: ${APP_URL}
+
 databases:
   - engine: PG
     name: newsletter

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -106,6 +106,7 @@ pub struct ApplicationSettings {
     pub host: String,
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub port: u16,
+    pub base_url: String,
 }
 
 #[derive(serde::Deserialize)]

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,5 +1,7 @@
 pub mod health_check;
 pub mod subscriptions;
+pub mod subscriptions_confirm;
 
 pub use health_check::*;
 pub use subscriptions::*;
+pub use subscriptions_confirm::*;

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -50,8 +50,8 @@ async fn insert_subscriber(
 ) -> Result<(), sqlx::Error> {
     sqlx::query!(
         r#"
-        INSERT INTO subscriptions (id, email, name, subscribed_at)
-        VALUES ($1, $2, $3, $4)
+        INSERT INTO subscriptions (id, email, name, subscribed_at, status)
+        VALUES ($1, $2, $3, $4, 'confirmed')
         "#,
         Uuid::new_v4(),
         new_subscriber.email.as_ref(),

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -1,5 +1,6 @@
 use crate::domain::SubscriberName;
 use crate::domain::{NewSubscriber, SubscriberEmail};
+use crate::email_client::EmailClient;
 use actix_web::{web, HttpResponse};
 use chrono::Utc;
 use sqlx::PgPool;
@@ -23,21 +24,31 @@ impl TryInto<NewSubscriber> for FormData {
 
 #[tracing::instrument(
     name = "Adding a new subscriber",
-    skip(connection_pool, form),
+    skip(connection_pool, email_client, form),
     fields(email = %form.email, name = %form.name)
 )]
 pub async fn subscribe(
     connection_pool: web::Data<PgPool>,
+    email_client: web::Data<EmailClient>,
     form: web::Form<FormData>,
 ) -> HttpResponse {
     let new_subscriber = match form.0.try_into() {
         Ok(value) => value,
         Err(_) => return HttpResponse::BadRequest().finish(),
     };
-    match insert_subscriber(&connection_pool, &new_subscriber).await {
-        Ok(_) => HttpResponse::Ok().finish(),
-        Err(_) => HttpResponse::InternalServerError().finish(),
+    if insert_subscriber(&connection_pool, &new_subscriber)
+        .await
+        .is_err()
+    {
+        return HttpResponse::InternalServerError().finish();
     }
+    if send_confirmation_email(&email_client, new_subscriber)
+        .await
+        .is_err()
+    {
+        return HttpResponse::InternalServerError().finish();
+    }
+    HttpResponse::Ok().finish()
 }
 
 #[tracing::instrument(
@@ -51,7 +62,7 @@ async fn insert_subscriber(
     sqlx::query!(
         r#"
         INSERT INTO subscriptions (id, email, name, subscribed_at, status)
-        VALUES ($1, $2, $3, $4, 'confirmed')
+        VALUES ($1, $2, $3, $4, 'pending_confirmation')
         "#,
         Uuid::new_v4(),
         new_subscriber.email.as_ref(),
@@ -66,4 +77,27 @@ async fn insert_subscriber(
     })?;
 
     Ok(())
+}
+
+#[tracing::instrument(
+    name = "Send a confirmation email to a new subscriber",
+    skip(email_client, new_subscriber)
+)]
+async fn send_confirmation_email(
+    email_client: &EmailClient,
+    new_subscriber: NewSubscriber,
+) -> Result<(), reqwest::Error> {
+    let confirmation_link = "https://my-api.com/subscriptions/confirm";
+    let html_body = format!(
+        "Welcome to our newsletter!<br />\
+                Click <a href=\"{}\">here</a> to confirm your subscription.",
+        confirmation_link
+    );
+    let plain_body = format!(
+        "Welcome to our newsletter!\nvisit {} to confirm your subscription.",
+        confirmation_link
+    );
+    email_client
+        .send_email(new_subscriber.email, "Welcome!", &html_body, &plain_body)
+        .await
 }

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -1,9 +1,13 @@
 use crate::domain::SubscriberName;
 use crate::domain::{NewSubscriber, SubscriberEmail};
 use crate::email_client::EmailClient;
+use crate::startup::ApplicationBaseUrl;
 use actix_web::{web, HttpResponse};
 use chrono::Utc;
-use sqlx::PgPool;
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
+use sqlx::{PgPool, Postgres, Transaction};
+use std::ops::DerefMut;
 use uuid::Uuid;
 
 #[derive(serde::Deserialize)]
@@ -24,52 +28,105 @@ impl TryInto<NewSubscriber> for FormData {
 
 #[tracing::instrument(
     name = "Adding a new subscriber",
-    skip(connection_pool, email_client, form),
+    skip(pool, email_client, base_url, form),
     fields(email = %form.email, name = %form.name)
 )]
 pub async fn subscribe(
-    connection_pool: web::Data<PgPool>,
+    pool: web::Data<PgPool>,
     email_client: web::Data<EmailClient>,
+    base_url: web::Data<ApplicationBaseUrl>,
     form: web::Form<FormData>,
 ) -> HttpResponse {
     let new_subscriber = match form.0.try_into() {
         Ok(value) => value,
         Err(_) => return HttpResponse::BadRequest().finish(),
     };
-    if insert_subscriber(&connection_pool, &new_subscriber)
+
+    let mut transaction = match pool.begin().await {
+        Ok(tx) => tx,
+        Err(_) => return HttpResponse::InternalServerError().finish(),
+    };
+
+    let subscriber_id = match insert_subscriber(&mut transaction, &new_subscriber).await {
+        Ok(value) => value,
+        Err(_) => return HttpResponse::InternalServerError().finish(),
+    };
+
+    let subscription_token = generate_subscription_token();
+    if store_token(&mut transaction, &subscriber_id, &subscription_token)
         .await
         .is_err()
     {
         return HttpResponse::InternalServerError().finish();
     }
-    if send_confirmation_email(&email_client, new_subscriber)
-        .await
-        .is_err()
+
+    if transaction.commit().await.is_err() {
+        return HttpResponse::InternalServerError().finish();
+    };
+
+    if send_confirmation_email(
+        &email_client,
+        new_subscriber,
+        &base_url.0,
+        &subscription_token,
+    )
+    .await
+    .is_err()
     {
         return HttpResponse::InternalServerError().finish();
     }
+
     HttpResponse::Ok().finish()
 }
 
 #[tracing::instrument(
     name = "Saving new subscriber details in the database",
-    skip(connection_pool, new_subscriber)
+    skip(tx, new_subscriber)
 )]
 async fn insert_subscriber(
-    connection_pool: &PgPool,
+    tx: &mut Transaction<'_, Postgres>,
     new_subscriber: &NewSubscriber,
-) -> Result<(), sqlx::Error> {
+) -> Result<Uuid, sqlx::Error> {
+    let subscriber_id = Uuid::new_v4();
+
     sqlx::query!(
         r#"
         INSERT INTO subscriptions (id, email, name, subscribed_at, status)
         VALUES ($1, $2, $3, $4, 'pending_confirmation')
         "#,
-        Uuid::new_v4(),
+        subscriber_id,
         new_subscriber.email.as_ref(),
         new_subscriber.name.as_ref(),
         Utc::now()
     )
-    .execute(connection_pool)
+    .execute(tx.deref_mut())
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to execute query: {:?}", e);
+        e
+    })?;
+
+    Ok(subscriber_id)
+}
+
+#[tracing::instrument(
+    name = "Store subscription token in the database",
+    skip(tx, subscription_token)
+)]
+async fn store_token(
+    tx: &mut Transaction<'_, Postgres>,
+    subscriber_id: &Uuid,
+    subscription_token: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        r#"
+        INSERT INTO subscription_tokens (subscriber_id, subscription_token)
+        values ($1, $2)
+        "#,
+        subscriber_id,
+        subscription_token
+    )
+    .execute(tx.deref_mut())
     .await
     .map_err(|e| {
         tracing::error!("Failed to execute query: {:?}", e);
@@ -86,8 +143,13 @@ async fn insert_subscriber(
 async fn send_confirmation_email(
     email_client: &EmailClient,
     new_subscriber: NewSubscriber,
+    base_url: &str,
+    subscription_token: &str,
 ) -> Result<(), reqwest::Error> {
-    let confirmation_link = "https://my-api.com/subscriptions/confirm";
+    let confirmation_link = format!(
+        "{}/subscriptions/confirm?subscription_token={}",
+        base_url, subscription_token
+    );
     let html_body = format!(
         "Welcome to our newsletter!<br />\
                 Click <a href=\"{}\">here</a> to confirm your subscription.",
@@ -100,4 +162,12 @@ async fn send_confirmation_email(
     email_client
         .send_email(new_subscriber.email, "Welcome!", &html_body, &plain_body)
         .await
+}
+
+fn generate_subscription_token() -> String {
+    let mut rng = thread_rng();
+    std::iter::repeat_with(|| rng.sample(Alphanumeric))
+        .map(char::from)
+        .take(25)
+        .collect()
 }

--- a/src/routes/subscriptions_confirm.rs
+++ b/src/routes/subscriptions_confirm.rs
@@ -1,0 +1,67 @@
+use actix_web::{web, HttpResponse};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(serde::Deserialize)]
+pub struct Parameters {
+    subscription_token: String,
+}
+
+#[tracing::instrument(name = "Confirm a pending subscriber", skip(pool, parameters))]
+pub async fn confirm(pool: web::Data<PgPool>, parameters: web::Query<Parameters>) -> HttpResponse {
+    let subscriber_id =
+        match get_subscriber_id_from_token(&pool, &parameters.subscription_token).await {
+            Ok(value) => value,
+            Err(_) => return HttpResponse::InternalServerError().finish(),
+        };
+
+    match subscriber_id {
+        Some(id) => {
+            if confirm_subscriber(&pool, id).await.is_err() {
+                return HttpResponse::InternalServerError().finish();
+            }
+            HttpResponse::Ok().finish()
+        }
+        // Token not found
+        None => HttpResponse::Unauthorized().finish(),
+    }
+}
+
+#[tracing::instrument(name = "Mark subscriber as confirmed", skip(pool, subscriber_id))]
+async fn confirm_subscriber(pool: &PgPool, subscriber_id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        r#"
+        UPDATE subscriptions SET status = 'confirmed' WHERE id = $1
+        "#,
+        subscriber_id
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to execute query: {:?}", e);
+        e
+    })?;
+
+    Ok(())
+}
+
+#[tracing::instrument(name = "Get subscriber_id from token", skip(pool, subscription_token))]
+async fn get_subscriber_id_from_token(
+    pool: &PgPool,
+    subscription_token: &str,
+) -> Result<Option<Uuid>, sqlx::Error> {
+    let record = sqlx::query!(
+        r#"
+        SELECT subscriber_id FROM subscription_tokens WHERE subscription_token = $1
+        "#,
+        subscription_token
+    )
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to execute query: {:?}", e);
+        e
+    })?;
+
+    Ok(record.map(|r| r.subscriber_id))
+}

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -23,9 +23,15 @@ static TRACING: Lazy<()> = Lazy::new(|| {
 
 pub struct TestApp {
     pub address: String,
+    pub port: u16,
     pub connection_pool: web::Data<PgPool>,
     pub database: DatabaseSettings,
     pub email_server: MockServer,
+}
+
+pub struct ConfirmationLinks {
+    pub html: reqwest::Url,
+    pub plain_text: reqwest::Url,
 }
 
 impl TestApp {
@@ -37,6 +43,29 @@ impl TestApp {
             .send()
             .await
             .expect("Failed to execute request.")
+    }
+
+    /// Extracts the confirmation links from the request to the email API.
+    pub fn get_confirmation_links(&self, email_request: &wiremock::Request) -> ConfirmationLinks {
+        let email_body: serde_json::Value = serde_json::from_slice(&email_request.body).unwrap();
+
+        let get_link = |s: &str| {
+            let links: Vec<_> = linkify::LinkFinder::new()
+                .links(s)
+                .filter(|l| *l.kind() == linkify::LinkKind::Url)
+                .collect();
+            assert_eq!(links.len(), 1);
+            let raw_link = links[0].as_str().to_owned();
+            let mut confirmation_link =
+                reqwest::Url::parse(&raw_link).expect("Failed to parse the link.");
+            assert_eq!(confirmation_link.host_str().unwrap(), "127.0.0.1");
+            confirmation_link.set_port(Some(self.port)).unwrap();
+            confirmation_link
+        };
+
+        let html = get_link(&email_body["HtmlBody"].as_str().unwrap());
+        let plain_text = get_link(&email_body["TextBody"].as_str().unwrap());
+        ConfirmationLinks { html, plain_text }
     }
 }
 
@@ -79,10 +108,12 @@ pub async fn spawn_app() -> TestApp {
         .expect("Failed to build application.");
     let connection_pool = application.get_connection_pool();
     let address = format!("http://127.0.0.1:{}", application.port);
+    let port = application.port;
     tokio::spawn(application.run_until_stopped());
 
     TestApp {
         address,
+        port,
         connection_pool,
         database: configurations.database,
         email_server,
@@ -104,6 +135,8 @@ async fn configure_database(db_settings: &DatabaseSettings) {
         .run(&connection_pool)
         .await
         .expect("Failed to run migrations.");
+    connection.close().await.unwrap();
+    connection_pool.close().await;
 }
 
 async fn clean_database(connect_options: PgConnectOptions, database_name: &str) {
@@ -114,4 +147,5 @@ async fn clean_database(connect_options: PgConnectOptions, database_name: &str) 
         .execute(format!(r#"DROP DATABASE "{}";"#, database_name).as_str())
         .await
         .expect("Failed to drop database.");
+    connection.close().await.unwrap();
 }

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,3 +1,4 @@
 mod health_check;
 mod helpers;
 mod subscriptions;
+mod subscriptions_confirm;

--- a/tests/api/subscriptions.rs
+++ b/tests/api/subscriptions.rs
@@ -1,5 +1,7 @@
 use crate::helpers::spawn_app;
 use sqlx::query;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
 
 /// This test is responsible for testing the /subscription endpoint.
 /// It will spawn our application and then send a POST request to the /subscription endpoint.
@@ -13,14 +15,37 @@ async fn subscribe_returns_a_200_for_valid_form_data() {
     let app = spawn_app().await;
     let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
 
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&app.email_server)
+        .await;
+
     // Act
     let response = app.post_subscriptions(body.into()).await;
 
     // Assert
     assert!(response.status().is_success());
     assert_eq!(200, response.status().as_u16());
+}
 
-    let saved = query!("SELECT email, name FROM subscriptions")
+#[tokio::test]
+async fn subscribe_persists_the_new_subscriber() {
+    // Arrange
+    let app = spawn_app().await;
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&app.email_server)
+        .await;
+
+    // Act
+    app.post_subscriptions(body.into()).await;
+
+    // Assert
+    let saved = query!("SELECT email, name, status FROM subscriptions")
         .fetch_one(app.connection_pool.as_ref())
         .await
         .expect("Failed to fetch saved subscription.");
@@ -29,6 +54,7 @@ async fn subscribe_returns_a_200_for_valid_form_data() {
 
     assert_eq!(saved.email, "ursula_le_guin@gmail.com");
     assert_eq!(saved.name, "le guin");
+    assert_eq!(saved.status, "pending_confirmation");
 }
 
 /// This test is responsible for testing the /subscription endpoint.
@@ -83,4 +109,70 @@ async fn subscribe_returns_a_400_when_fields_are_present_but_empty() {
             description
         );
     }
+}
+
+#[tokio::test]
+async fn subscribe_sends_a_confirmation_email_for_valid_data() {
+    // Arrange
+    let app = spawn_app().await;
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&app.email_server)
+        .await;
+
+    // Act
+    app.post_subscriptions(body.into()).await;
+
+    // Assert
+}
+
+#[tokio::test]
+async fn subscribe_sends_a_confirmation_email_with_a_link() {
+    // Arrange
+    let app = spawn_app().await;
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&app.email_server)
+        .await;
+
+    // Act
+    let response = app.post_subscriptions(body.into()).await;
+
+    // Assert
+    assert!(response.status().is_success());
+    assert_eq!(200, response.status().as_u16());
+
+    let saved = query!("SELECT email, name FROM subscriptions")
+        .fetch_one(app.connection_pool.as_ref())
+        .await
+        .expect("Failed to fetch saved subscription.");
+
+    app.connection_pool.close().await;
+
+    assert_eq!(saved.email, "ursula_le_guin@gmail.com");
+    assert_eq!(saved.name, "le guin");
+
+    let email_request = &app.email_server.received_requests().await.unwrap()[0];
+    let body: serde_json::Value = serde_json::from_slice(&email_request.body).unwrap();
+
+    let get_link = |s: &str| {
+        let links: Vec<_> = linkify::LinkFinder::new()
+            .links(s)
+            .filter(|l| *l.kind() == linkify::LinkKind::Url)
+            .collect();
+        assert_eq!(links.len(), 1);
+
+        links[0].as_str().to_owned()
+    };
+
+    let html_link = get_link(&body["HtmlBody"].as_str().unwrap());
+    let text_link = get_link(&body["TextBody"].as_str().unwrap());
+    assert_eq!(html_link, text_link);
 }

--- a/tests/api/subscriptions.rs
+++ b/tests/api/subscriptions.rs
@@ -143,36 +143,10 @@ async fn subscribe_sends_a_confirmation_email_with_a_link() {
         .await;
 
     // Act
-    let response = app.post_subscriptions(body.into()).await;
+    app.post_subscriptions(body.into()).await;
 
     // Assert
-    assert!(response.status().is_success());
-    assert_eq!(200, response.status().as_u16());
-
-    let saved = query!("SELECT email, name FROM subscriptions")
-        .fetch_one(app.connection_pool.as_ref())
-        .await
-        .expect("Failed to fetch saved subscription.");
-
-    app.connection_pool.close().await;
-
-    assert_eq!(saved.email, "ursula_le_guin@gmail.com");
-    assert_eq!(saved.name, "le guin");
-
     let email_request = &app.email_server.received_requests().await.unwrap()[0];
-    let body: serde_json::Value = serde_json::from_slice(&email_request.body).unwrap();
-
-    let get_link = |s: &str| {
-        let links: Vec<_> = linkify::LinkFinder::new()
-            .links(s)
-            .filter(|l| *l.kind() == linkify::LinkKind::Url)
-            .collect();
-        assert_eq!(links.len(), 1);
-
-        links[0].as_str().to_owned()
-    };
-
-    let html_link = get_link(&body["HtmlBody"].as_str().unwrap());
-    let text_link = get_link(&body["TextBody"].as_str().unwrap());
-    assert_eq!(html_link, text_link);
+    let confirmation_links = app.get_confirmation_links(email_request);
+    assert_eq!(confirmation_links.html, confirmation_links.plain_text);
 }

--- a/tests/api/subscriptions_confirm.rs
+++ b/tests/api/subscriptions_confirm.rs
@@ -1,0 +1,81 @@
+use crate::helpers::spawn_app;
+use sqlx::query;
+use wiremock::matchers::{method, path};
+use wiremock::Mock;
+
+#[tokio::test]
+async fn confirmations_without_token_are_rejected_with_a_400() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = reqwest::get(&format!("{}/subscriptions/confirm", app.address))
+        .await
+        .expect("Failed to execute a request.");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn the_link_returned_by_subscribe_returns_a_200_if_called() {
+    // Arrange
+    let app = spawn_app().await;
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(wiremock::ResponseTemplate::new(200))
+        .mount(&app.email_server)
+        .await;
+
+    app.post_subscriptions(body.into()).await;
+
+    let email_request = &app.email_server.received_requests().await.unwrap()[0];
+    let confirmation_links = app.get_confirmation_links(email_request);
+
+    // Act
+    let response = reqwest::get(confirmation_links.html)
+        .await
+        .expect("Failed to execute a request.");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+}
+
+#[tokio::test]
+async fn clicking_on_the_confirmation_link_confirms_a_subscriber() {
+    // Arrange
+    let app = spawn_app().await;
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(wiremock::ResponseTemplate::new(200))
+        .mount(&app.email_server)
+        .await;
+
+    app.post_subscriptions(body.into()).await;
+
+    let email_request = &app.email_server.received_requests().await.unwrap()[0];
+    let confirmation_links = app.get_confirmation_links(email_request);
+
+    // Act
+    reqwest::get(confirmation_links.html)
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+
+    // Assert
+    let saved = query!("SELECT email, name, status FROM subscriptions")
+        .fetch_one(app.connection_pool.as_ref())
+        .await
+        .expect("Failed to fetch saved subscription.");
+
+    app.connection_pool.close().await;
+
+    assert_eq!(saved.email, "ursula_le_guin@gmail.com");
+    assert_eq!(saved.name, "le guin");
+    assert_eq!(saved.status, "confirmed");
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Migrated the database schema.
- Added a step to generate a token for email confirmation during the subscription process. The token will be included as a query parameter in the confirmation URL within the confirmation email.
- Added a new email confirmation endpoint at `/subscriptions/confirm`. This endpoint receives the generated token and updates the subscription status from `pending_confirmation` to `confirmed`.