### PR TITLE
Implement Functionality for Publishing Newsletter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1403,7 @@ name = "newsletter"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "anyhow",
  "chrono",
  "claim",
  "config",
@@ -1412,6 +1419,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "sqlx",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 actix-web = "4"
+anyhow = "1"
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 claim = "0.5"
 config = "0.14"
@@ -22,6 +23,7 @@ rand = { version = "0.8", features = ["std_rng"] }
 secrecy = { version = "0.8", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde-aux = "4"
+thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-actix-web = "0.7"

--- a/scripts/test_with_logging.sh
+++ b/scripts/test_with_logging.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export RUST_LOG="sqlx=error,info"
+export TEST_LOG="enabled"
+cargo test subscribe_fails_if_there_is_a_fatal_database_error | bunyan

--- a/scripts/test_with_logging.sh
+++ b/scripts/test_with_logging.sh
@@ -2,4 +2,4 @@
 
 export RUST_LOG="sqlx=error,info"
 export TEST_LOG="enabled"
-cargo test subscribe_fails_if_there_is_a_fatal_database_error | bunyan
+cargo test "$@" | bunyan

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,3 +1,4 @@
+use crate::domain::subscriber_email::EmailParsingError;
 use crate::domain::SubscriberEmail;
 use secrecy::{ExposeSecret, Secret};
 use serde_aux::field_attributes::deserialize_number_from_string;
@@ -118,7 +119,7 @@ pub struct EmailClientSettings {
 }
 
 impl EmailClientSettings {
-    pub fn sender(&self) -> Result<SubscriberEmail, String> {
+    pub fn sender(&self) -> Result<SubscriberEmail, EmailParsingError> {
         SubscriberEmail::parse(self.sender_email.clone())
     }
 

--- a/src/domain/subscriber_email.rs
+++ b/src/domain/subscriber_email.rs
@@ -1,4 +1,5 @@
 use crate::errors::ParsingError;
+use std::fmt::{Debug, Display};
 use validator::ValidateEmail;
 
 #[derive(Debug)]
@@ -17,6 +18,12 @@ impl SubscriberEmail {
 impl AsRef<str> for SubscriberEmail {
     fn as_ref(&self) -> &str {
         &self.0
+    }
+}
+
+impl Display for SubscriberEmail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
     }
 }
 

--- a/src/domain/subscriber_email.rs
+++ b/src/domain/subscriber_email.rs
@@ -1,14 +1,15 @@
+use crate::errors::ParsingError;
 use validator::ValidateEmail;
 
 #[derive(Debug)]
 pub struct SubscriberEmail(String);
 
 impl SubscriberEmail {
-    pub fn parse(s: String) -> Result<Self, String> {
+    pub fn parse(s: String) -> Result<Self, EmailParsingError> {
         if ValidateEmail::validate_email(&s) {
             Ok(Self(s))
         } else {
-            Err("Invalid email address".into())
+            Err(EmailParsingError)
         }
     }
 }
@@ -18,6 +19,24 @@ impl AsRef<str> for SubscriberEmail {
         &self.0
     }
 }
+
+#[derive(Debug)]
+pub struct EmailParsingError;
+
+impl std::fmt::Display for EmailParsingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Invalid email address.")
+    }
+}
+
+impl From<Box<EmailParsingError>> for Box<dyn ParsingError> {
+    fn from(value: Box<EmailParsingError>) -> Self {
+        value
+    }
+}
+
+impl std::error::Error for EmailParsingError {}
+impl ParsingError for EmailParsingError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/domain/subscriber_name.rs
+++ b/src/domain/subscriber_name.rs
@@ -1,15 +1,16 @@
+use crate::errors::ParsingError;
 use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Debug)]
 pub struct SubscriberName(String);
 
 impl SubscriberName {
-    pub fn parse(s: String) -> Result<Self, String> {
+    pub fn parse(s: String) -> Result<Self, NameParsingError> {
         if Self::is_empty_or_whitespace(&s)
             || Self::is_too_long(&s)
             || Self::contains_forbidden_characters(&s)
         {
-            Err("Invalid subscriber name".into())
+            Err(NameParsingError)
         } else {
             Ok(Self(s))
         }
@@ -37,6 +38,24 @@ impl AsRef<str> for SubscriberName {
         &self.0
     }
 }
+
+#[derive(Debug)]
+pub struct NameParsingError;
+
+impl std::fmt::Display for NameParsingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Invalid subscriber name.")
+    }
+}
+
+impl From<Box<NameParsingError>> for Box<dyn ParsingError> {
+    fn from(value: Box<NameParsingError>) -> Self {
+        value
+    }
+}
+
+impl std::error::Error for NameParsingError {}
+impl ParsingError for NameParsingError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/email_client.rs
+++ b/src/email_client.rs
@@ -30,7 +30,7 @@ impl EmailClient {
 
     pub async fn send_email(
         &self,
-        recipient: SubscriberEmail,
+        recipient: &SubscriberEmail,
         subject: &str,
         html_content: &str,
         text_content: &str,
@@ -136,7 +136,7 @@ mod tests {
 
         // Act
         let _ = email_client
-            .send_email(email(), &subject(), &content(), &content())
+            .send_email(&email(), &subject(), &content(), &content())
             .await;
 
         // Assert
@@ -156,7 +156,7 @@ mod tests {
 
         // Act
         let outcome = email_client
-            .send_email(email(), &subject(), &content(), &content())
+            .send_email(&email(), &subject(), &content(), &content())
             .await;
 
         // Assert
@@ -177,7 +177,7 @@ mod tests {
 
         // Act
         let outcome = email_client
-            .send_email(email(), &subject(), &content(), &content())
+            .send_email(&email(), &subject(), &content(), &content())
             .await;
 
         // Assert
@@ -199,7 +199,7 @@ mod tests {
 
         // Act
         let outcome = email_client
-            .send_email(email(), &subject(), &content(), &content())
+            .send_email(&email(), &subject(), &content(), &content())
             .await;
 
         // Assert

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,15 @@
+use std::fmt::Formatter;
+
+pub fn error_chain_fmt(e: &impl std::error::Error, f: &mut Formatter<'_>) -> std::fmt::Result {
+    writeln!(f, "{}", e)?;
+    let mut current = e.source();
+    while let Some(cause) = current {
+        writeln!(f, "Caused by:\n\t{}", cause)?;
+        current = cause.source();
+    }
+    Ok(())
+}
+
+pub trait ParsingError: std::error::Error {}
+
+impl std::error::Error for Box<dyn ParsingError> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod configuration;
 pub mod domain;
 pub mod email_client;
+pub mod errors;
 pub mod routes;
 pub mod startup;
 pub mod telemetry;

--- a/src/routes/health_check.rs
+++ b/src/routes/health_check.rs
@@ -1,5 +1,11 @@
 use actix_web::{HttpResponse, Responder};
 
+/// Check if the server is running.
+/// This always returns a 200 OK status code.
+///
+/// # Response
+///
+/// - **200 OK**: The server is running.
 pub async fn health_check() -> impl Responder {
     HttpResponse::Ok()
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -2,6 +2,6 @@ pub mod health_check;
 pub mod subscriptions;
 pub mod subscriptions_confirm;
 
-pub use health_check::*;
-pub use subscriptions::*;
-pub use subscriptions_confirm::*;
+pub use health_check::health_check;
+pub use subscriptions::subscribe;
+pub use subscriptions_confirm::confirm;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,7 +1,9 @@
 pub mod health_check;
+mod newsletters;
 pub mod subscriptions;
 pub mod subscriptions_confirm;
 
 pub use health_check::health_check;
+pub use newsletters::publish_newsletter;
 pub use subscriptions::subscribe;
 pub use subscriptions_confirm::confirm;

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -1,0 +1,95 @@
+use crate::domain::SubscriberEmail;
+use crate::email_client::EmailClient;
+use crate::errors::error_chain_fmt;
+use actix_web::http::StatusCode;
+use actix_web::{web, HttpResponse, ResponseError};
+use anyhow::Context;
+use sqlx::PgPool;
+use std::fmt::{Debug, Display};
+
+#[derive(serde::Deserialize)]
+pub struct BodyData {
+    title: String,
+    content: Content,
+}
+
+#[derive(serde::Deserialize)]
+pub struct Content {
+    html: String,
+    text: String,
+}
+
+#[tracing::instrument(name = "Publish a newsletter", skip(pool, email_client, body))]
+pub async fn publish_newsletter(
+    pool: web::Data<PgPool>,
+    email_client: web::Data<EmailClient>,
+    body: web::Json<BodyData>,
+) -> Result<HttpResponse, PublishError> {
+    let subscribers = get_confirmed_subscribers(&pool).await?;
+    for subscriber in subscribers {
+        match subscriber {
+            Ok(subscriber) => email_client
+                .send_email(
+                    &subscriber.email,
+                    &body.title,
+                    &body.content.html,
+                    &body.content.text,
+                )
+                .await
+                .context(format!(
+                    "Failed to send newsletter issue to {}",
+                    subscriber.email
+                ))?,
+            Err(e) => tracing::warn!("Skipping invalid subscriber email: {}", e),
+        }
+    }
+    Ok(HttpResponse::Ok().finish())
+}
+
+#[derive(thiserror::Error)]
+pub enum PublishError {
+    #[error(transparent)]
+    UnexpectedError(#[from] anyhow::Error),
+}
+
+impl Debug for PublishError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        error_chain_fmt(self, f)
+    }
+}
+
+impl ResponseError for PublishError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            PublishError::UnexpectedError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+struct ConfirmedSubscriber {
+    email: SubscriberEmail,
+}
+
+impl Display for ConfirmedSubscriber {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.email)
+    }
+}
+
+#[tracing::instrument(name = "Get confirmed subscribers", skip(pool))]
+async fn get_confirmed_subscribers(
+    pool: &PgPool,
+) -> Result<Vec<Result<ConfirmedSubscriber, anyhow::Error>>, anyhow::Error> {
+    let confirmed_subscribers =
+        sqlx::query!("SELECT email FROM subscriptions WHERE status = 'confirmed'")
+            .fetch_all(pool)
+            .await?
+            .into_iter()
+            .map(|row| match SubscriberEmail::parse(row.email) {
+                Ok(email) => Ok(ConfirmedSubscriber { email }),
+                Err(error) => Err(anyhow::anyhow!(error)),
+            })
+            .collect();
+
+    Ok(confirmed_subscribers)
+}

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -245,7 +245,7 @@ async fn send_confirmation_email(
         confirmation_link
     );
     email_client
-        .send_email(new_subscriber.email, "Welcome!", &html_body, &plain_body)
+        .send_email(&new_subscriber.email, "Welcome!", &html_body, &plain_body)
         .await
 }
 

--- a/src/routes/subscriptions_confirm.rs
+++ b/src/routes/subscriptions_confirm.rs
@@ -1,29 +1,98 @@
-use actix_web::{web, HttpResponse};
+use crate::errors::error_chain_fmt;
+use actix_web::http::StatusCode;
+use actix_web::{web, HttpResponse, ResponseError};
+use anyhow::Context;
 use sqlx::PgPool;
+use std::fmt::{Debug, Formatter};
 use uuid::Uuid;
+use SubscribeConfirmError::*;
 
+/// The query parameters for the confirm endpoint.
+///
+/// # Fields
+///
+/// - `subscription_token`: The token that was sent to the subscriber's email.
 #[derive(serde::Deserialize)]
 pub struct Parameters {
     subscription_token: String,
 }
 
+/// Confirm a pending subscriber.
+///
+/// # Request
+///
+/// ### Query Parameters
+///
+/// The query parameters will be passed as `parameters`, an instance of [Parameters].
+/// `subscription_token` field is required.
+///
+/// Field                | Description
+/// ---------------------|---------------------------------------------------
+/// `subscription_token` | The token that was sent to the subscriber's email.
+///
+/// See [Parameters] for more information.
+///
+/// # Response
+///
+/// - **200 OK**: The subscriber has been confirmed.
+/// - **401 Unauthorized**: The token is invalid.
+/// - **500 Internal Server Error**: An error occurred while processing the request.
+///
+/// # Errors
+///
+/// This function can return two types of errors:
+///
+/// 1. [TokenNotFoundError]
+///
+///    The token is invalid. It will be converted into a 401 Unauthorized response.
+///
+/// 2. [UnexpectedError]:
+///
+///    An error occurred while processing the request.
+///    It will be converted into a 500 Internal Server Error response.
 #[tracing::instrument(name = "Confirm a pending subscriber", skip(pool, parameters))]
-pub async fn confirm(pool: web::Data<PgPool>, parameters: web::Query<Parameters>) -> HttpResponse {
-    let subscriber_id =
-        match get_subscriber_id_from_token(&pool, &parameters.subscription_token).await {
-            Ok(value) => value,
-            Err(_) => return HttpResponse::InternalServerError().finish(),
-        };
+pub async fn confirm(
+    pool: web::Data<PgPool>,
+    parameters: web::Query<Parameters>,
+) -> Result<HttpResponse, SubscribeConfirmError> {
+    let subscriber_id = get_subscriber_id_from_token(&pool, &parameters.subscription_token)
+        .await
+        .context("Failed to get subscriber ID from the database.")?;
 
     match subscriber_id {
         Some(id) => {
-            if confirm_subscriber(&pool, id).await.is_err() {
-                return HttpResponse::InternalServerError().finish();
-            }
-            HttpResponse::Ok().finish()
+            confirm_subscriber(&pool, id)
+                .await
+                .context("Failed to set status `confirmed` in the database")?;
+            Ok(HttpResponse::Ok().finish())
         }
-        // Token not found
-        None => HttpResponse::Unauthorized().finish(),
+        None => Err(TokenNotFoundError),
+    }
+}
+
+/// The error type for the confirm endpoint.
+#[derive(thiserror::Error)]
+pub enum SubscribeConfirmError {
+    /// The subscription token is invalid.
+    #[error("Failed to find subscriber. The token is invalid.")]
+    TokenNotFoundError,
+    /// An error occurred while processing the request.
+    #[error(transparent)]
+    UnexpectedError(#[from] anyhow::Error),
+}
+
+impl ResponseError for SubscribeConfirmError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            TokenNotFoundError => StatusCode::UNAUTHORIZED,
+            UnexpectedError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl Debug for SubscribeConfirmError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        error_chain_fmt(self, f)
     }
 }
 
@@ -36,11 +105,7 @@ async fn confirm_subscriber(pool: &PgPool, subscriber_id: Uuid) -> Result<(), sq
         subscriber_id
     )
     .execute(pool)
-    .await
-    .map_err(|e| {
-        tracing::error!("Failed to execute query: {:?}", e);
-        e
-    })?;
+    .await?;
 
     Ok(())
 }
@@ -57,11 +122,7 @@ async fn get_subscriber_id_from_token(
         subscription_token
     )
     .fetch_optional(pool)
-    .await
-    .map_err(|e| {
-        tracing::error!("Failed to execute query: {:?}", e);
-        e
-    })?;
+    .await?;
 
     Ok(record.map(|r| r.subscriber_id))
 }

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,6 +1,6 @@
 use crate::configuration::Settings;
 use crate::email_client::EmailClient;
-use crate::routes::{confirm, health_check, subscribe};
+use crate::routes::{confirm, health_check, publish_newsletter, subscribe};
 use actix_web::dev::Server;
 use actix_web::{web, App, HttpServer};
 use sqlx::postgres::PgPoolOptions;
@@ -83,6 +83,7 @@ fn run(
             .route("/health_check", web::get().to(health_check))
             .route("/subscriptions", web::post().to(subscribe))
             .route("/subscriptions/confirm", web::get().to(confirm))
+            .route("/newsletters", web::post().to(publish_newsletter))
             .app_data(connection_pool.clone())
             .app_data(email_client.clone())
             .app_data(base_url.clone())

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -3,6 +3,7 @@ use newsletter_lib::configuration::{get_configuration, DatabaseSettings};
 use newsletter_lib::startup::Application;
 use newsletter_lib::telemetry::{get_subscriber, init_subscriber};
 use once_cell::sync::Lazy;
+use reqwest::Response;
 use sqlx::postgres::PgConnectOptions;
 use sqlx::{Connection, Executor, PgConnection, PgPool};
 use uuid::Uuid;
@@ -66,6 +67,15 @@ impl TestApp {
         let html = get_link(&email_body["HtmlBody"].as_str().unwrap());
         let plain_text = get_link(&email_body["TextBody"].as_str().unwrap());
         ConfirmationLinks { html, plain_text }
+    }
+
+    pub async fn post_newsletters(&self, body: serde_json::Value) -> Response {
+        reqwest::Client::new()
+            .post(&format!("{}/newsletters", self.address))
+            .json(&body)
+            .send()
+            .await
+            .expect("Failed to execute request.")
     }
 }
 

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,4 +1,5 @@
 mod health_check;
 mod helpers;
+mod newsletters;
 mod subscriptions;
 mod subscriptions_confirm;

--- a/tests/api/newsletters.rs
+++ b/tests/api/newsletters.rs
@@ -1,0 +1,150 @@
+use crate::helpers::{spawn_app, ConfirmationLinks, TestApp};
+use wiremock::matchers::{any, method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+async fn create_unconfirmed_subscriber(app: &TestApp) -> ConfirmationLinks {
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    let _mock_guard = Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .named("Create unconfirmed subscriber")
+        .expect(1)
+        .mount_as_scoped(&app.email_server)
+        .await;
+    app.post_subscriptions(body.into())
+        .await
+        .error_for_status()
+        .unwrap();
+    let email_request = &app
+        .email_server
+        .received_requests()
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    app.get_confirmation_links(email_request)
+}
+
+async fn create_confirmed_subscriber(app: &TestApp) {
+    let confirmation_links = create_unconfirmed_subscriber(app).await;
+    reqwest::get(confirmation_links.html)
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+}
+
+#[tokio::test]
+async fn newsletters_are_not_delivered_to_unconfirmed_subscribers() {
+    // Arrange
+    let app = spawn_app().await;
+    create_unconfirmed_subscriber(&app).await;
+
+    Mock::given(any())
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&app.email_server)
+        .await;
+
+    // Act
+    // Skeleton code for sending a newsletter.
+    // TODO: Edit later.
+    let newsletter_request_body = serde_json::json!({
+        "title": "Newsletter title",
+        "content": {
+            "text": "Newsletter body as plain text",
+            "html": "<p>Newsletter body as HTML</p>"
+        }
+    });
+    let response = app.post_newsletters(newsletter_request_body).await;
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    // Mock is dropped here and
+    // verify whether the newsletter email was not sent to the unconfirmed subscriber.
+}
+
+#[tokio::test]
+async fn newsletters_are_delivered_to_confirmed_subscribers() {
+    // Arrange
+    let app = spawn_app().await;
+    create_confirmed_subscriber(&app).await;
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&app.email_server)
+        .await;
+
+    // Act
+    let newsletter_request_body = serde_json::json!({
+        "title": "Newsletter title",
+        "content": {
+            "text": "Newsletter body as plain text",
+            "html": "<p>Newsletter body as HTML</p>"
+        }
+    });
+    let response = app.post_newsletters(newsletter_request_body).await;
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    // Mock is dropped here and
+    // verify whether the newsletter email was sent to the confirmed subscriber.
+}
+
+#[tokio::test]
+async fn newsletters_returns_400_for_invalid_data() {
+    // Arrange
+    let app = spawn_app().await;
+    let test_cases = vec![
+        (
+            serde_json::json!({
+                "content": {
+                    "text": "Newsletter body as plain text",
+                    "html": "<p>Newsletter body as HTML</p>",
+                }
+            }),
+            "missing title",
+        ),
+        (
+            serde_json::json!({"title": "Newsletter title",}),
+            "missing content",
+        ),
+        (
+            serde_json::json!({
+                "title": "Newsletter title",
+                "content": {
+                    "text": "Newsletter body as plain text",
+                }
+            }),
+            "missing content.html",
+        ),
+        (
+            serde_json::json!({
+                "title": "Newsletter title",
+                "content": {
+                    "html": "<p>Newsletter body as HTML</p>",
+                }
+            }),
+            "missing content.text",
+        ),
+    ];
+
+    for (invalid_body, error_message) in test_cases {
+        // Act
+        let response = app.post_newsletters(invalid_body).await;
+
+        // Assert
+        assert_eq!(
+            400,
+            response.status().as_u16(),
+            "The API did not fail with 400 Bad Request when the payload was {}.",
+            error_message
+        );
+    }
+}

--- a/tests/api/subscriptions.rs
+++ b/tests/api/subscriptions.rs
@@ -150,3 +150,23 @@ async fn subscribe_sends_a_confirmation_email_with_a_link() {
     let confirmation_links = app.get_confirmation_links(email_request);
     assert_eq!(confirmation_links.html, confirmation_links.plain_text);
 }
+
+#[tokio::test]
+async fn subscribe_fails_if_there_is_a_fatal_database_error() {
+    // Arrange
+    let app = spawn_app().await;
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    // Drop the subscriptions table to force a database error
+    // sqlx::query!("ALTER TABLE subscription_tokens DROP COLUMN subscription_token;")
+    sqlx::query!("ALTER TABLE subscriptions DROP COLUMN email;")
+        .execute(app.connection_pool.as_ref())
+        .await
+        .expect("Failed to drop the subscriptions table");
+
+    // Act
+    let response = app.post_subscriptions(body.into()).await;
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 500);
+}


### PR DESCRIPTION
This pull request contains two main changes:

## Added Error Handling for More Informative Log

I improved the application logging to capture the causes of HTTP error status codes.
To achieve this, I modified the request handlers to return a `Result` with error objects implementing `actix_web::error::ResponseError` trait instead of returning `HttpResponse` directly.
`actix_web` now logs these returned errors and converts them to HTTP error status codes.

## Implemented Functionality for Publishing Newsletter

I introduced a new `/newsletters` endpoint to distribute newsletter content via emails.
This endpoint takes an email body as JSON and sends it to all confirmed subscribers.